### PR TITLE
Fix typo modelMatrix -> model_matrix

### DIFF
--- a/viewer/src/components/Viewer.jsx
+++ b/viewer/src/components/Viewer.jsx
@@ -74,7 +74,7 @@ export const Viewer = ({
                 },
               ]
             : d.labels,
-          model_matrix: modelMatrices?.[index] || d.modelMatrix,
+          model_matrix: modelMatrices?.[index] || d.model_matrix,
         });
       });
       setLayerStates(ls);


### PR DESCRIPTION
# Description

This fixes a bug where the `dataset.coordinateTransformations` from the OME-Zarr metadata were getting ignored.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] All tests pass (eg. `npm test`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)


To test:

 - Try these 2 samples (from discussion at https://github.com/hms-dbmi/vizarr/pull/259) `source=https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457227.zarr&source=https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457537.zarr`
  - Without this PR, they are both aligned to the same top-left corner.
  - With this PR, the smaller image is offset in x, y and z. When fully zoomed in, the smaller image actually disappears in Z, but if you zoom out, it will appear. It's also easier to see if you reduce opacity of the bigger image:


<img width="753" height="549" alt="Screenshot 2025-08-22 at 14 43 04" src="https://github.com/user-attachments/assets/88abe57b-9a4b-4e2b-8f64-38a73f42de81" />
