### PR TITLE
compute orthographic view near and far to avoid clipping with non-0 z coords

### DIFF
--- a/viewer/src/components/Viewer.jsx
+++ b/viewer/src/components/Viewer.jsx
@@ -240,7 +240,7 @@ export const Viewer = ({
     const zs = layers.flatMap((layer) => {
       const { modelMatrix: matrix } = layer?.props || {};
       if (!matrix) {
-        return null;
+        return [];
       }
       const { width, height } = getLayerSize(layers[0]);
       const corners = [
@@ -256,8 +256,8 @@ export const Viewer = ({
     const maxZ = Math.max(...zs);
 
     return {
-      near: maxZ ? -10000 * maxZ : 0.1,
-      far: minZ ? 1000 * minZ : 1000,
+      near: maxZ ? -10000 * Math.abs(maxZ) : 0.1,
+      far: minZ ? 10000 * Math.abs(minZ) : 1000,
     };
   }, [layers]);
 


### PR DESCRIPTION
# Description

Default `near` and far `values` for `OrthographicView` could cause layers with z transformations to not be rendered at specific zooming levels
e.g. http://localhost:5173/?source=https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457537.zarr would need to be zoomed out for layer to be visible
`near` and `far` are now computed from min and max Z coords of all layers

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Checklist

- [ ] All tests pass (eg. `npm test`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)
